### PR TITLE
Issue-304: Create GHA to copy over documentation

### DIFF
--- a/.github/workflows/copy-docs.yml
+++ b/.github/workflows/copy-docs.yml
@@ -1,0 +1,24 @@
+name : Copy Docs
+on: 
+  push:
+    branches:
+      - main
+    paths:
+      - '/README.md'
+ 
+jobs:
+  copy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Copycat
+      uses: andstor/copycat-action@v3
+      with:
+        commit_message: "Syncing from kubearmor-integration"
+        clean: false
+        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        src_path: /README.md
+        dst_path: /docs/kubearmor-integration/index.md
+        dst_owner: open-horizon
+        dst_repo_name: open-horizon.github.io
+        dst_branch: master
+        src_branch: main


### PR DESCRIPTION
#304: Add GitHub Action to copy /README.md to /docs/kubearmor-integration

Signed-off-by: Joe Pearson <joe.pearson@us.ibm.com>

This copies `/README.md` to documentation website path `/docs/kubearmor-integration/index.md`