### PR TITLE
Issue #17 - Documentation: Fix lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,40 +8,41 @@ a systemd process.
 
 <p align="center"><img src="resources/imgs/OH-edge-kubearmor.png" width="768"></p>
 
-KubeArmor running on the edge node provides visibility and protection for all the processes, files, or network operations in the containers as well as those running directly on the host.  
+KubeArmor running on the edge node provides visibility and protection for all the processes, files, or network operations in the containers as well as those running directly on the host.
 
 **Observability:** KubeArmor can provide container-aware observability information about the operations happening:
-1) from Agent node to Management Hub (and vice-versa)  
-2) between the containers and the agent edge node  
+
+1) from Agent node to Management Hub (and vice-versa)
+2) between the containers and the agent edge node
 3) inside the containers running on the Agent node
 
 **Enforcement:** KubeArmor can be used to apply security postures at the kernel level (using LSMs like AppArmor, BPF-LSM). It can protect both the host and workloads running on it by enforcing either some predefined security policies or automatically generated least permissive security policies (using Discovery Engine).
 
-KubeArmor already supports k8s-orchestrated workloads and provides[ KVMService](https://github.com/kubearmor/kvm-service) that allows orchestrating security policies to VMs for non-k8s environments.  
+KubeArmor already supports k8s-orchestrated workloads and provides [KVMService](https://github.com/kubearmor/kvm-service) that allows orchestrating security policies to VMs for non-k8s environments.
 With v0.5.5 release, KubeArmor now supports standalone un-orchestrated containers. KubeArmor in this mode supports both enforcement and observability of the host and the containers running on it.
 
 ## KubeArmor on Open Horizon
 
 > **Note**
-> This guide assumes both the Open Horizon Management Hub and Agent VM are running Ubuntu 20.04.  
-We will first need to install Open Horizon Management Hub and Agent node components. For that please follow the [Open Horizon setup](https://github.com/kubearmor/KubeArmor/wiki/Open-Horizon-setup) guide.  
+> This guide assumes both the Open Horizon Management Hub and Agent VM are running Ubuntu 20.04.
+We will first need to install Open Horizon Management Hub and Agent node components. For that please follow the [Open Horizon setup](https://github.com/kubearmor/KubeArmor/wiki/Open-Horizon-setup) guide.
 We also assume that [Open Horizon Home Assistant service](https://github.com/open-horizon-services/service-homeassistant) is running on the agent edge node.
 
 <p align="center"><img src="resources/imgs/OH-detailed.png" width="768"></p>
 
 Now we will run KubeArmor as a systemd process on the Open Horizon Agent VM
 
-## Installation KubeArmor, kArmor, and Discovery Engine  
+## Installation KubeArmor, kArmor, and Discovery Engine
 
 * **KubeArmor Installation:**
 
-1. Download the [latest release](https://github.com/kubearmor/KubeArmor/releases) of KubeArmor  
+1. Download the [latest release](https://github.com/kubearmor/KubeArmor/releases) of KubeArmor
 
    ```bash
    wget https://github.com/kubearmor/KubeArmor/releases/download/v0.5.5/kubearmor_0.5.5_linux-amd64.deb
    ```
 
-2. Install KubeArmor 
+2. Install KubeArmor
 
    ```bash
    sudo apt install ./kubearmor_0.5.5_linux-amd64.deb
@@ -56,11 +57,13 @@ Now we will run KubeArmor as a systemd process on the Open Horizon Agent VM
 i. Refer [Installing BCC](https://github.com/iovisor/bcc/blob/master/INSTALL.md#installing-bcc) to install pre-requisites.
 
 ii. Download release tarball from KubeArmor [releases](https://github.com/kubearmor/KubeArmor/releases)
+
     ```bash
     wget https://github.com/kubearmor/KubeArmor/releases/download/v0.5.5/kubearmor_0.5.5_linux-amd64.tar.gz
     ```
 
 iii. Unpack the tarball to the root directory:
+
      ```bash
      sudo tar --no-overwrite-dir -C / -xzf kubearmor_0.5.5_linux-amd64.tar.gz
      ```
@@ -84,9 +87,9 @@ iii. Unpack the tarball to the root directory:
 
 * **kArmor Installation:**
 
-> **Note** kArmor should already be installed by the above KubeArmor installation. Check installation using `karmor version`.  
+> **Note** kArmor should already be installed by the above KubeArmor installation. Check installation using `karmor version`.
 
-If kArmor is not installed run:    
+If kArmor is not installed run:
 
 ```bash
 curl -sfL http://get.kubearmor.io/ | sudo sh -s -- -b /usr/local/bin
@@ -94,13 +97,13 @@ curl -sfL http://get.kubearmor.io/ | sudo sh -s -- -b /usr/local/bin
 
 * **Discovery Engine Installation:**
 
-1. Download the [latest release](https://github.com/accuknox/discovery-engine/releases) of Discovery Engine  
+1. Download the [latest release](https://github.com/accuknox/discovery-engine/releases) of Discovery Engine
 
    ```bash
    wget https://github.com/accuknox/discovery-engine/releases/download/v0.6.3/knoxAutoPolicy_0.6.3_linux-amd64.deb
    ```
 
-2. Install Discovery Engine 
+2. Install Discovery Engine
 
    ```bash
    sudo apt install ./knoxAutoPolicy_0.6.3_linux-amd64.deb
@@ -111,25 +114,29 @@ curl -sfL http://get.kubearmor.io/ | sudo sh -s -- -b /usr/local/bin
 <p>
 
 i. Download release tarball from KubeArmor [releases](https://github.com/kubearmor/KubeArmor/releases)
+
    ```bash
    wget https://github.com/accuknox/discovery-engine/releases/download/v0.6.3/knoxAutoPolicy_0.6.3_linux-amd64.tar.gz
    ```
 
 ii. Unpack the tarball to the root directory:
+
     ```bash
     sudo tar --no-overwrite-dir -C / -xzf knoxAutoPolicy_0.6.3_linux-amd64.tar.gz
     ```
+
 </p>
 </details>
 
 ---
 
-3. Start Discovery Engine  
+3. Start Discovery Engine
 
   ```bash
-  sudo systemctl daemon-reload  
+  sudo systemctl daemon-reload
   sudo systemctl start knoxAutoPolicy
   ```
+
 If you have previously installed discovery-engine, it's advised to restart the service `sudo systemctl restart knoxAutoPolicy`
 
 4. To check Discovery Engine running status
@@ -144,7 +151,7 @@ If you have previously installed discovery-engine, it's advised to restart the s
    karmor log
    ```
 
-6. Now, let’s apply a sample policy: *block-secrets-access.yaml* using:
+6. Now, let's apply a sample policy: *block-secrets-access.yaml* using:
 
    ```bash
    karmor vm policy add block-secrets-access.yaml
@@ -181,7 +188,7 @@ spec:
 
 </details>
 
-Note: More predefined policies and auto-discovered policy can be found here: [https://github.com/kubearmor/openhorizon-demo/tree/main/Open-Horizon/policies](https://github.com/kubearmor/openhorizon-demo/tree/main/Open-Horizon/policies) 
+Note: More predefined policies and auto-discovered policy can be found here: [https://github.com/kubearmor/openhorizon-demo/tree/main/Open-Horizon/policies](https://github.com/kubearmor/openhorizon-demo/tree/main/Open-Horizon/policies)
 
 Here notice the field `kubearmor.io/container.name: homeassistant` homeassistant is the container name to which we want to apply the policy.
 
@@ -217,36 +224,43 @@ Tags: WARNING
 <details>
 <summary>Available filters</summary>
 
-```
+```text
 --logFilter <system|policy|all> - Filter to receive general system logs (system) or alerts on policy violation (policy) or both (all).
 --logType <ContainerLog|HostLog> - Source of logs - ContainerLog: logs from containers or HostLog: logs from the host
 --operation <Process|File|Network> - Type of logs based on process, file or network
 --container - Specify container name to view container specific logs
 ```
+
 </details>
 
 </details>
 
 This will create an AppArmor profile at `/etc/apparmor.d/` with the name `kubearmor_<containername>` (kubearmor_homeassistant here) and will load the profile to AppArmor.
- 
+
 ### Apply the AppArmor profile to the desired container
+
 To run a container with KubeArmor enforcement using the AppArmor profile kubearmor_homeassistant, pass `--security-opt apparmor=kubearmor_homeassistant` with the `docker run` command or if using docker-compose add:`security_opts: apparmor=kubearmor_homeassistant` under the container name in the docker-compose.yaml.
 
 ## Auto discover least permissive security policy
+
 `karmor discover` tool can be used to automatically generate security policies. The output of the command can be redirected to a yaml file
+
 ```bash
 karmor discover --format yaml --labels "kubearmor.io/container.name=homeassistant" > discovered_policy.yaml
 ```
-This yaml file can be applied to KubeArmor to provide the least permissive security posture for the homeassistant-service container.  
 
-To apply security policy `discovered_policy.yaml`  
+This yaml file can be applied to KubeArmor to provide the least permissive security posture for the homeassistant-service container.
+
+To apply security policy `discovered_policy.yaml`
 
 ```bash
 karmor vm policy add discovered_policy.yaml
 ```
-> **Note**: Host security policies are identified by `kind: KubeArmorHostPolicy` and Container security policies have `kind: KubeArmorPolicy`. 
 
-### Uninstall KubeArmor, kArmor, and Discovery Engine  
+> **Note**: Host security policies are identified by `kind: KubeArmorHostPolicy` and Container security policies have `kind: KubeArmorPolicy`.
+
+### Uninstall KubeArmor, kArmor, and Discovery Engine
+
 We will first stop the KubeArmor and Discovery Engine system service and then will uninstall the packages.
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,40 +8,41 @@ a systemd process.
 
 <p align="center"><img src="./OH-edge-kubearmor.png" width="768"></p>
 
-KubeArmor running on the edge node provides visibility and protection for all the processes, files, or network operations in the containers as well as those running directly on the host.  
+KubeArmor running on the edge node provides visibility and protection for all the processes, files, or network operations in the containers as well as those running directly on the host.
 
 **Observability:** KubeArmor can provide container-aware observability information about the operations happening:
-1) from Agent node to Management Hub (and vice-versa)  
-2) between the containers and the agent edge node  
+
+1) from Agent node to Management Hub (and vice-versa)
+2) between the containers and the agent edge node
 3) inside the containers running on the Agent node
 
 **Enforcement:** KubeArmor can be used to apply security postures at the kernel level (using LSMs like AppArmor, BPF-LSM). It can protect both the host and workloads running on it by enforcing either some predefined security policies or automatically generated least permissive security policies (using Discovery Engine).
 
-KubeArmor already supports k8s-orchestrated workloads and provides[ KVMService](https://github.com/kubearmor/kvm-service) that allows orchestrating security policies to VMs for non-k8s environments.  
+KubeArmor already supports k8s-orchestrated workloads and provides [KVMService](https://github.com/kubearmor/kvm-service) that allows orchestrating security policies to VMs for non-k8s environments.
 With v0.5.5 release, KubeArmor now supports standalone un-orchestrated containers. KubeArmor in this mode supports both enforcement and observability of the host and the containers running on it.
 
 ## KubeArmor on Open Horizon
 
 > **Note**
-> This guide assumes both the Open Horizon Management Hub and Agent VM are running Ubuntu 20.04.  
-We will first need to install Open Horizon Management Hub and Agent node components. For that please follow the [Open Horizon setup](https://github.com/kubearmor/KubeArmor/wiki/Open-Horizon-setup) guide.  
+> This guide assumes both the Open Horizon Management Hub and Agent VM are running Ubuntu 20.04.
+We will first need to install Open Horizon Management Hub and Agent node components. For that please follow the [Open Horizon setup](https://github.com/kubearmor/KubeArmor/wiki/Open-Horizon-setup) guide.
 We also assume that [Open Horizon Home Assistant service](https://github.com/open-horizon-services/service-homeassistant) is running on the agent edge node.
 
 <p align="center"><img src="./OH-detailed.png" width="768"></p>
 
 Now we will run KubeArmor as a systemd process on the Open Horizon Agent VM
 
-## Installation KubeArmor, kArmor, and Discovery Engine  
+## Installation KubeArmor, kArmor, and Discovery Engine
 
 * **KubeArmor Installation:**
 
-1. Download the [latest release](https://github.com/kubearmor/KubeArmor/releases) of KubeArmor  
+1. Download the [latest release](https://github.com/kubearmor/KubeArmor/releases) of KubeArmor
 
    ```bash
    wget https://github.com/kubearmor/KubeArmor/releases/download/v0.5.5/kubearmor_0.5.5_linux-amd64.deb
    ```
 
-2. Install KubeArmor 
+2. Install KubeArmor
 
    ```bash
    sudo apt install ./kubearmor_0.5.5_linux-amd64.deb
@@ -56,11 +57,13 @@ Now we will run KubeArmor as a systemd process on the Open Horizon Agent VM
 i. Refer [Installing BCC](https://github.com/iovisor/bcc/blob/master/INSTALL.md#installing-bcc) to install pre-requisites.
 
 ii. Download release tarball from KubeArmor [releases](https://github.com/kubearmor/KubeArmor/releases)
+
     ```bash
     wget https://github.com/kubearmor/KubeArmor/releases/download/v0.5.5/kubearmor_0.5.5_linux-amd64.tar.gz
     ```
 
 iii. Unpack the tarball to the root directory:
+
      ```bash
      sudo tar --no-overwrite-dir -C / -xzf kubearmor_0.5.5_linux-amd64.tar.gz
      ```
@@ -82,13 +85,11 @@ iii. Unpack the tarball to the root directory:
    sudo journalctl -u kubearmor -f
    ```
 
-
-
 * **kArmor Installation:**
 
-> **Note** kArmor should already be installed by the above KubeArmor installation. Check installation using `karmor version`.  
+> **Note** kArmor should already be installed by the above KubeArmor installation. Check installation using `karmor version`.
 
-If kArmor is not installed run:    
+If kArmor is not installed run:
 
 ```bash
 curl -sfL http://get.kubearmor.io/ | sudo sh -s -- -b /usr/local/bin
@@ -96,43 +97,46 @@ curl -sfL http://get.kubearmor.io/ | sudo sh -s -- -b /usr/local/bin
 
 * **Discovery Engine Installation:**
 
-1. Download the [latest release](https://github.com/accuknox/discovery-engine/releases) of Discovery Engine  
+1. Download the [latest release](https://github.com/accuknox/discovery-engine/releases) of Discovery Engine
 
    ```bash
    wget https://github.com/accuknox/discovery-engine/releases/download/v0.6.3/knoxAutoPolicy_0.6.3_linux-amd64.deb
    ```
 
-2. Install Discovery Engine 
+2. Install Discovery Engine
 
    ```bash
    sudo apt install ./knoxAutoPolicy_0.6.3_linux-amd64.deb
    ```
-
 
 ---
 <details><summary> Note: For distributions other than Ubuntu/Debian</summary>
 <p>
 
 i. Download release tarball from KubeArmor [releases](https://github.com/kubearmor/KubeArmor/releases)
+
    ```bash
    wget https://github.com/accuknox/discovery-engine/releases/download/v0.6.3/knoxAutoPolicy_0.6.3_linux-amd64.tar.gz
    ```
 
 ii. Unpack the tarball to the root directory:
+
     ```bash
     sudo tar --no-overwrite-dir -C / -xzf knoxAutoPolicy_0.6.3_linux-amd64.tar.gz
     ```
+
 </p>
 </details>
 
 ---
 
-3. Start Discovery Engine  
+3. Start Discovery Engine
 
   ```bash
-  sudo systemctl daemon-reload  
+  sudo systemctl daemon-reload
   sudo systemctl start knoxAutoPolicy
   ```
+
 If you have previously installed discovery-engine, it's advised to restart the service `sudo systemctl restart knoxAutoPolicy`
 
 4. To check Discovery Engine running status
@@ -147,7 +151,7 @@ If you have previously installed discovery-engine, it's advised to restart the s
    karmor log
    ```
 
-6. Now, let’s apply a sample policy: *block-secrets-access.yaml* using:
+6. Now, let's apply a sample policy: *block-secrets-access.yaml* using:
 
    ```bash
    karmor vm policy add block-secrets-access.yaml
@@ -184,7 +188,7 @@ spec:
 
 </details>
 
-Note: More predefined policies and auto-discovered policy can be found here: [https://github.com/kubearmor/openhorizon-demo/tree/main/Open-Horizon/policies](https://github.com/kubearmor/openhorizon-demo/tree/main/Open-Horizon/policies) 
+Note: More predefined policies and auto-discovered policy can be found here: [https://github.com/kubearmor/openhorizon-demo/tree/main/Open-Horizon/policies](https://github.com/kubearmor/openhorizon-demo/tree/main/Open-Horizon/policies)
 
 Here notice the field `kubearmor.io/container.name: homeassistant` homeassistant is the container name to which we want to apply the policy.
 
@@ -220,37 +224,43 @@ Tags: WARNING
 <details>
 <summary>Available filters</summary>
 
-```
+```text
 --logFilter <system|policy|all> - Filter to receive general system logs (system) or alerts on policy violation (policy) or both (all).
 --logType <ContainerLog|HostLog> - Source of logs - ContainerLog: logs from containers or HostLog: logs from the host
 --operation <Process|File|Network> - Type of logs based on process, file or network
 --container - Specify container name to view container specific logs
 ```
-</details>
 
 </details>
 
+</details>
 
 This will create an AppArmor profile at `/etc/apparmor.d/` with the name `kubearmor_<containername>` (kubearmor_homeassistant here) and will load the profile to AppArmor.
- 
+
 ### Apply the AppArmor profile to the desired container
+
 To run a container with KubeArmor enforcement using the AppArmor profile kubearmor_homeassistant, pass `--security-opt apparmor=kubearmor_homeassistant` with the `docker run` command or if using docker-compose add:`security_opts: apparmor=kubearmor_homeassistant` under the container name in the docker-compose.yaml.
 
 ## Auto discover least permissive security policy
+
 `karmor discover` tool can be used to automatically generate security policies. The output of the command can be redirected to a yaml file
+
 ```bash
 karmor discover --format yaml --labels "kubearmor.io/container.name=homeassistant" > discovered_policy.yaml
 ```
-This yaml file can be applied to KubeArmor to provide the least permissive security posture for the homeassistant-service container.  
 
-To apply security policy `discovered_policy.yaml`  
+This yaml file can be applied to KubeArmor to provide the least permissive security posture for the homeassistant-service container.
+
+To apply security policy `discovered_policy.yaml`
 
 ```bash
 karmor vm policy add discovered_policy.yaml
 ```
-> **Note**: Host security policies are identified by `kind: KubeArmorHostPolicy` and Container security policies have `kind: KubeArmorPolicy`. 
 
-### Uninstall KubeArmor, kArmor, and Discovery Engine  
+> **Note**: Host security policies are identified by `kind: KubeArmorHostPolicy` and Container security policies have `kind: KubeArmorPolicy`.
+
+### Uninstall KubeArmor, kArmor, and Discovery Engine
+
 We will first stop the KubeArmor and Discovery Engine system service and then will uninstall the packages.
 
 ```bash


### PR DESCRIPTION
Fixes: #17 

- Fix lint warnings
- Extra trailing spaces
- whitespace around code blocks
- wrong unicode for single quote

Once this PR is merged, check that the rendered page looks good:
- https://open-horizon.github.io/docs/kubearmor-integration/docs/README/